### PR TITLE
Fix BitcoinClient LoadWallet Errors

### DIFF
--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -320,7 +320,9 @@ export default class BitcoinClient {
     } catch (e) {
       // using error message because bitcoin core error code is not reliable as a single code can contain multiple errors
       const duplicateLoadString = 'already loaded';
-      if (e.toString().toLowerCase().includes(duplicateLoadString)) {
+      // this error is seen on some versions of bitcoin core when loading a loaded wallet, including v0.20.1
+      const alternateDuplicateLoadString = 'Duplicate -wallet filename specified';
+      if (e.toString().toLowerCase().includes(duplicateLoadString) || e.toString().includes(alternateDuplicateLoadString)) {
         Logger.info(`Wallet with name ${this.walletNameToUse} already loaded.`);
       } else {
         throw e;

--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -308,7 +308,7 @@ export default class BitcoinClient {
   private async loadWallet () {
     const request = {
       method: 'loadwallet',
-      params: [this.walletNameToUse, true] // the wallet name
+      params: [this.walletNameToUse] // the wallet name
     };
 
     // Intentionally not throwing because bitcoin returns 500 when a wallet is already loaded

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -412,7 +412,7 @@ describe('BitcoinClient', async () => {
       await bitcoinClient['loadWallet']();
       expect(rpcSpy).toHaveBeenCalledWith({
         method: 'loadwallet',
-        params: ['sidetreeDefaultWallet', true]
+        params: ['sidetreeDefaultWallet']
       }, true, false);
       expect(loggerSpy).toHaveBeenCalledWith(`Wallet loaded with name "sidetreeDefaultWallet".`);
     });
@@ -425,7 +425,7 @@ describe('BitcoinClient', async () => {
       } catch {
         expect(rpcSpy).toHaveBeenCalledWith({
           method: 'loadwallet',
-          params: ['sidetreeDefaultWallet', true]
+          params: ['sidetreeDefaultWallet']
         }, true, false);
       }
     });
@@ -436,7 +436,7 @@ describe('BitcoinClient', async () => {
       await bitcoinClient['loadWallet']();
       expect(rpcSpy).toHaveBeenCalledWith({
         method: 'loadwallet',
-        params: ['sidetreeDefaultWallet', true]
+        params: ['sidetreeDefaultWallet']
       }, true, false);
       expect(loggerSpy).toHaveBeenCalledWith(`Wallet with name sidetreeDefaultWallet already loaded.`);
     });


### PR DESCRIPTION
[Don't pass second param to loadWallet](https://github.com/decentralized-identity/sidetree-reference-impl/commit/d1bc2a2cdda99df6d468e9e1c6385a1eeb151f59)

This second boolean parameter causes an error on error on Bitcoin Core v0.20.1 and v25.0. It is not a documented parameter in v25 and newer versions of Bitcoin Core.

This parameter, in some versions of bitcoin, was supposed to cause a wallet to be automatically loaded, but this is unnecessary as sidetree makes a loadwallet call anyway.

[Catch duplicate loadWallet error](https://github.com/decentralized-identity/sidetree-reference-impl/commit/380c788825e26a556a5946b9c07a510be6c29f8f)